### PR TITLE
Support command 'asdf install hey latest'

### DIFF
--- a/.github/workflows/asdf.yml
+++ b/.github/workflows/asdf.yml
@@ -20,7 +20,7 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v1
         with:
           command: hey --help
-          version: v0.1.4
+          version: 0.1.4
   lint:
     runs-on: ubuntu-latest
 

--- a/bin/install
+++ b/bin/install
@@ -17,7 +17,7 @@ install_tool() {
 
     platform=$(get_platform)
     arch_name=$(get_arch)
-    download_url=$(get_download_url "${version}" "${platform}" "${arch_name}")
+    download_url=$(get_download_url "v${version}" "${platform}" "${arch_name}")
     download_path="${tmp_download_dir}/${binary_name}"
 
     echo "Downloading [${binary_name}] from ${download_url} to ${download_path}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -15,14 +15,14 @@ list-all() {
         # Fallback when token is not set
         local tags_path="https://github.com/${github_repo}/tags"
         cmd="${cmd} ${tags_path}"
-        versions=$(eval "${cmd}" | grep -E -o "/${github_repo}/releases/tag/v[0-9].[0-9].[0-9][0-9]?" | awk -F '/' '{ print $6 }' | sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n -u | tr '\n' ' ')
+        versions=$(eval "${cmd}" | grep -E -o "/${github_repo}/releases/tag/v[0-9].[0-9].[0-9][0-9]?" | awk -F '/' '{ print $6 }' | sort_versions | tr '\n' ' ')
     fi
 
     echo "${versions}"
 }
 
 sort_versions() {
-    sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+    sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/v//g; s/\n/ /' |
         LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 


### PR DESCRIPTION
Needed to remove `v` from `list-all` script results.

As-is:
```sh
$ asdf list-all hey
v0.1.0
v0.1.1
v0.1.2
v0.1.2
v0.1.3
v0.1.4
```

To-be:
```sh
$ asdf list-all hey
0.1.0
0.1.1
0.1.2
0.1.2
0.1.3
0.1.4
```