### PR TITLE
Migrate install step from Linuxbrew to apt

### DIFF
--- a/.github/workflows/asdf.yml
+++ b/.github/workflows/asdf.yml
@@ -29,7 +29,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install shellcheck
-        run: brew install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install shellcheck
 
       - name: Run ShellCheck
         run: make test


### PR DESCRIPTION
Migrate to `apt-get` command because shellcheck can no longer be installed with the `brew` command.